### PR TITLE
Fix remove bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/LocalOverrides.targets

--- a/SFCore.csproj
+++ b/SFCore.csproj
@@ -17,6 +17,7 @@
     <ExportDir Condition="$([MSBuild]::IsOSPlatform('Windows'))">E:/Documents/Projects/__Exports/</ExportDir>
     <DocumentationFile>$(OutputPath)/$(AssemblyTitle).xml</DocumentationFile>
   </PropertyGroup>
+  <Import Project="LocalOverrides.targets" Condition="Exists('LocalOverrides.targets')" />
   <Target Name="CopyMod" AfterTargets="PostBuildEvent">
     <RemoveDir Condition="Exists('$(ExportDir)/$(TargetName)/')" Directories="$(ExportDir)/$(TargetName)/" />
     <MakeDir Directories="$(ExportDir)/$(TargetName)/" />

--- a/Util/FsmUtil.cs
+++ b/Util/FsmUtil.cs
@@ -408,6 +408,28 @@ public static class FsmUtil
         fsm.Fsm.States = newStates;
     }
 
+    private static FsmTransition[] RemoveTransition(FsmTransition[] orig, string eventName)
+    {
+        int index = -1;
+        for (int i = 0; i < orig.Length; i++)
+        {
+            if (orig[i].EventName == eventName)
+            {
+                index = i;
+                break;
+            }
+        }
+        if (index == -1) return orig;
+
+        FsmTransition[] newTransitions = new FsmTransition[orig.Length - 1];
+        for (int i = 0; i < orig.Length; i++)
+        {
+            if (i < index) newTransitions[i] = orig[i];
+            else if (i > index) newTransitions[i - 1] = orig[i];
+        }
+        return newTransitions;
+    }
+
     /// <summary>
     /// Removes a transition in a PlayMakerFSM.
     /// </summary>
@@ -426,19 +448,7 @@ public static class FsmUtil
     public static void RemoveTransition(this FsmState state, string eventName) => state.RemoveFsmTransition(eventName);
     /// <inheritdoc cref="RemoveTransition(FsmState, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmTransition(this FsmState state, string eventName)
-    {
-        FsmTransition[] origTransitions = state.Transitions;
-        int found = 0;
-        foreach (FsmTransition transition in origTransitions) if (transition.EventName == eventName) found++;
-
-        if (found == 0) return;
-        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - found];
-
-        int index = 0;
-        foreach (FsmTransition transition in origTransitions) if (transition.EventName != eventName) newTransitions[index++] = transition;
-        state.Transitions = newTransitions;
-    }
+    public static void RemoveFsmTransition(this FsmState state, string eventName) => state.Transitions = RemoveTransition(state.Transitions, eventName);
 
     /// <summary>
     /// Removes a global transition in a PlayMakerFSM.
@@ -449,19 +459,7 @@ public static class FsmUtil
     public static void RemoveGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.RemoveFsmGlobalTransition(eventName);
     /// <inheritdoc cref="RemoveGlobalTransition(PlayMakerFSM, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName)
-    {
-        FsmTransition[] origTransitions = fsm.FsmGlobalTransitions;
-        int found = 0;
-        foreach (FsmTransition transition in origTransitions) if (transition.EventName == eventName) found++;
-
-        if (found == 0) return;
-        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - found];
-
-        int index = 0;
-        foreach (FsmTransition transition in origTransitions) if (transition.EventName != eventName) newTransitions[index++] = transition;
-        fsm.Fsm.GlobalTransitions = newTransitions;
-    }
+    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.Fsm.GlobalTransitions = RemoveTransition(fsm.FsmGlobalTransitions, eventName);
 
     /// <summary>
     /// Removes an action in a PlayMakerFSM.

--- a/Util/FsmUtil.cs
+++ b/Util/FsmUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using HutongGames.PlayMaker;
 using JetBrains.Annotations;
 using Logger = Modding.Logger;
@@ -84,7 +85,7 @@ public static class FsmUtil
     [UsedImplicitly]
     public static TAction GetFsmAction<TAction>(this PlayMakerFSM fsm, string stateName, int index) where TAction : FsmStateAction
     {
-        return (TAction) fsm.GetFsmState(stateName).Actions[index];
+        return (TAction)fsm.GetFsmState(stateName).Actions[index];
     }
 
     #endregion
@@ -426,23 +427,7 @@ public static class FsmUtil
     public static void RemoveTransition(this FsmState state, string eventName) => state.RemoveFsmTransition(eventName);
     /// <inheritdoc cref="RemoveTransition(FsmState, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmTransition(this FsmState state, string eventName)
-    {
-        FsmTransition[] origTransitions = state.Transitions;
-        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - 1];
-        int i;
-        int foundInt = 0;
-        for (i = 0; i < newTransitions.Length; i++)
-        {
-            if (origTransitions[i].EventName == eventName)
-            {
-                foundInt = 1;
-            }
-            newTransitions[i] = origTransitions[i + foundInt];
-        }
-
-        state.Transitions = newTransitions;
-    }
+    public static void RemoveFsmTransition(this FsmState state, string eventName) => state.Transitions = state.Transitions.Where(t => t.EventName != eventName).ToArray();
 
     /// <summary>
     /// Removes a global transition in a PlayMakerFSM.
@@ -453,23 +438,7 @@ public static class FsmUtil
     public static void RemoveGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.RemoveFsmGlobalTransition(eventName);
     /// <inheritdoc cref="RemoveGlobalTransition(PlayMakerFSM, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName)
-    {
-        FsmTransition[] origTransitions = fsm.FsmGlobalTransitions;
-        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - 1];
-        int i;
-        int foundInt = 0;
-        for (i = 0; i < newTransitions.Length; i++)
-        {
-            if (origTransitions[i].EventName == eventName)
-            {
-                foundInt = 1;
-            }
-            newTransitions[i] = origTransitions[i + foundInt];
-        }
-
-        fsm.Fsm.GlobalTransitions = newTransitions;
-    }
+    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.Fsm.GlobalTransitions = fsm.Fsm.GlobalTransitions.Where(t => t.EventName != eventName).ToArray();
 
     /// <summary>
     /// Removes an action in a PlayMakerFSM.

--- a/Util/FsmUtil.cs
+++ b/Util/FsmUtil.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using HutongGames.PlayMaker;
 using JetBrains.Annotations;
 using Logger = Modding.Logger;
@@ -427,7 +426,19 @@ public static class FsmUtil
     public static void RemoveTransition(this FsmState state, string eventName) => state.RemoveFsmTransition(eventName);
     /// <inheritdoc cref="RemoveTransition(FsmState, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmTransition(this FsmState state, string eventName) => state.Transitions = state.Transitions.Where(t => t.EventName != eventName).ToArray();
+    public static void RemoveFsmTransition(this FsmState state, string eventName)
+    {
+        FsmTransition[] origTransitions = state.Transitions;
+        int found = 0;
+        foreach (FsmTransition transition in origTransitions) if (transition.EventName == eventName) found++;
+
+        if (found == 0) return;
+        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - found];
+
+        int index = 0;
+        foreach (FsmTransition transition in origTransitions) if (transition.EventName != eventName) newTransitions[index++] = transition;
+        state.Transitions = newTransitions;
+    }
 
     /// <summary>
     /// Removes a global transition in a PlayMakerFSM.
@@ -438,7 +449,19 @@ public static class FsmUtil
     public static void RemoveGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.RemoveFsmGlobalTransition(eventName);
     /// <inheritdoc cref="RemoveGlobalTransition(PlayMakerFSM, string)"/>
     [UsedImplicitly]
-    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName) => fsm.Fsm.GlobalTransitions = fsm.Fsm.GlobalTransitions.Where(t => t.EventName != eventName).ToArray();
+    public static void RemoveFsmGlobalTransition(this PlayMakerFSM fsm, string eventName)
+    {
+        FsmTransition[] origTransitions = fsm.FsmGlobalTransitions;
+        int found = 0;
+        foreach (FsmTransition transition in origTransitions) if (transition.EventName == eventName) found++;
+
+        if (found == 0) return;
+        FsmTransition[] newTransitions = new FsmTransition[origTransitions.Length - found];
+
+        int index = 0;
+        foreach (FsmTransition transition in origTransitions) if (transition.EventName != eventName) newTransitions[index++] = transition;
+        fsm.Fsm.GlobalTransitions = newTransitions;
+    }
 
     /// <summary>
     /// Removes an action in a PlayMakerFSM.


### PR DESCRIPTION
RemoveFsmGlobalTransition() (and affiliates) is bugged, and will remove the last transition on the list if there is no matching event name.  This PR simplifies the relevant methods with System.Linq and fixes the bug(s).

If System.Linq is being explictly avoided, lmk and I'll rewrite the functions without it.