### PR TITLE
Fix NRE in SceneManagerPatcher by loading prefabs on init

### DIFF
--- a/MonoBehaviours/SceneManagerPatcher.cs
+++ b/MonoBehaviours/SceneManagerPatcher.cs
@@ -17,6 +17,17 @@ public class SceneManagerPatcher : MonoBehaviour
     private static AudioMixer _actorAm = null;
     private static AudioMixer _shadeAm = null;
 
+    private static GameObject _borderPrefab = null;
+    private static GameObject _hollowShadePrefab = null;
+    private static GameObject _dreamgatePrefab = null;
+
+    internal static void LoadPrefabs(SceneManager template)
+    {
+        _borderPrefab = template.borderPrefab;
+        _hollowShadePrefab = template.hollowShadeObject;
+        _dreamgatePrefab = template.dreamgateObject;
+    }
+
     /// <summary>
     /// The area of the map this scene belongs to.
     /// </summary>
@@ -278,10 +289,10 @@ public class SceneManagerPatcher : MonoBehaviour
         Modding.Logger.Log($"SsSnapshotName: {SsSnapshotName}");
         sm.shadeSnapshot = _shadeAm.FindSnapshot(SsSnapshotName);
         sm.transitionTime = transitionTime;
-        sm.borderPrefab = GameObject.Find("SceneBorder");
+        sm.borderPrefab = _borderPrefab;
         sm.manualMapTrigger = manualMapTrigger;
-        sm.hollowShadeObject = GameObject.Find("Hollow Shade");
-        sm.dreamgateObject = GameObject.Find("dream_gate_object");
+        sm.hollowShadeObject = _hollowShadePrefab;
+        sm.dreamgateObject = _dreamgatePrefab;
 
         smGo.SetActive(true);
     }

--- a/SFCore.cs
+++ b/SFCore.cs
@@ -1,6 +1,9 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Reflection;
 using SFCore.Generics;
+using SFCore.MonoBehaviours;
 using SFCore.Utils;
+using UnityEngine;
 
 namespace SFCore;
 
@@ -35,10 +38,17 @@ public class SFCoreMod : FullSettingsMod<SFCoreSaveSettings, SFCoreGlobalSetting
     public override string GetVersion() => Util.GetVersion(Assembly.GetExecutingAssembly());
 
     /// <summary>
+    /// Get names of objects to preload.
+    /// </summary>
+    /// <returns>List of (scene, name) tuples to preload.</returns>
+    public override List<(string, string)> GetPreloadNames() => new() { ("Town", "_SceneManager") };
+
+    /// <summary>
     /// Main menu is loaded.
     /// </summary>
-    public override void Initialize()
+    public override void Initialize(Dictionary<string, Dictionary<string, GameObject>> preloadedObjects)
     {
+        SceneManagerPatcher.LoadPrefabs(preloadedObjects["Town"]["_SceneManager"].GetComponent<SceneManager>());
     }
 }
 


### PR DESCRIPTION
Added Hollow Knight scenes don't necessarily have these game objects sitting at the root, so the patcher should load them from an existing scene instead.